### PR TITLE
Add variable to control SSL cert validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Role Variables
 --------------
 
     ---
+    validate_certs: True
     usg_controller_base_path: /usr/lib/unifi 
     usg_controller_process_user: unifi
     usg_controller_process_group: unifi
@@ -29,6 +30,10 @@ Role Variables
 
 Explanation of variables
 ------------------------
+
+    validate_certs: True
+
+When using the UniFi controller's self-signed SSL certificate, you should set this variable to `False` in order to not have the API fail.
 
     usg_controller_base_path: /usr/lib/unifi
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
+validate_certs: True
 usg_controller_base_path: /usr/lib/unifi # https://help.ui.com/hc/en-us/articles/115004872967-UniFi-Where-is-unifi-base-
 usg_controller_process_user: unifi
 usg_controller_process_group: unifi

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,6 +35,7 @@
         body:
           username: "{{ usg_controller_username }}"
           password: "{{ usg_controller_password }}"
+        validate_certs: "{{ validate_certs }}"
       register: controller_login
 
     - name: Provision the USG/USG Pro device(s)
@@ -46,6 +47,7 @@
           mac: "{{ item.usg_mac }}"
         headers:
           Cookie: "{{ controller_login.cookies_string }}"
+        validate_certs: "{{ validate_certs }}"
       when: item.provision
       loop: "{{ usg_controller_sites }}"
 
@@ -55,3 +57,4 @@
         method: GET
         headers:
           Cookie: "{{ controller_login.cookies_string }}"
+        validate_certs: "{{ validate_certs }}"


### PR DESCRIPTION
This PR adds the ability to enable/disable SSL cert validation via a variable.

Fixes https://github.com/ljurgs/unifi-config-gateway-json/issues/1